### PR TITLE
Using dashjs p2p bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,12 @@ A video.js source handler for supporting MPEG-DASH playback over P2P or CDN thro
 
 ## Getting started
 
-Run `npm install` to install necessary dependencies such as [streamroot-dashjs-p2p-wrapper](https://github.com/streamroot/dashjs-p2p-wrapper) and build the source handler. Build is triggered automatically after `npm install`.
-
+Run `npm install` to install necessary dependencies such as [streamroot-dashjs-p2p-bundle](https://github.com/streamroot/dashjs-p2p-wrapper) and build the source handler. Build is triggered automatically after `npm install`.
 You can also use `grunt build` to build the files after a manual update.
 
 The built files will be placed into `dist` directory.
 
-In addition to built files, you'll need to include [video.js 5.0+](http://videojs.com/getting-started/) and `dash.js` v2.1.1+ in your web page. For `dash.js` you can use either its [minified](http://dashif.org/reference/players/javascript/v2.1.1/dash.js/dist/dash.all.min.js) or [debug](http://dashif.org/reference/players/javascript/v2.1.1/dash.js/dist/dash.all.debug.js) version.
+In addition to built files, you'll need to include [video.js 5.0+](http://videojs.com/getting-started/) in your web page.
 
 To enable a graphic visualization of P2P traffic (as a debug tool), you can add following lines to your page. Note that in this case, `p2pConfig` must include `debug: true` as described [here](https://streamroot.readme.io/docs/p2p-config) :
 
@@ -27,15 +26,13 @@ Putting it all together:
 ```html
 <html>
 <head>
-  <!-- dash.js -->
-  <script src="http://dashif.org/reference/players/javascript/2.1.1/dash.js/dist/dash.all.debug.js"></script>
 
   <!-- video.js -->
   <link href="//vjs.zencdn.net/5.8/video-js.min.css" rel="stylesheet">
   <script src="//vjs.zencdn.net/5.8/video.min.js"></script>
 
   <!-- videojs-contrib-dash script -->
-  <script src="dist/vjs5-dashjs-source-handler.js"></script>
+  <script src="dist/videojs5-dashjs-p2p-source-handler.js"></script>
 
   <!-- p2p graphics and peer stats -->
   <script src="http://cdn.streamroot.io/2/scripts/p2pGraph.js"></script>
@@ -89,36 +86,33 @@ For a quick p2p test you can open several tabs with the same manifest and start 
 
 ## How it works
 
-[streamroot-dashjs-p2p-wrapper](https://github.com/streamroot/dashjs-p2p-wrapper) is added as a dependency into `package.json`
+[streamroot-dashjs-p2p-bundle](https://github.com/streamroot/dashjs-p2p-wrapper) is added as a dependency into `package.json`
 
 ```json
   ...
   "dependencies": {
-    "dashjs": "2.1.1",
     "global": "^4.3.0",
     "video.js": "^5.0.0",
-    "streamroot-dashjs-p2p-wrapper": "^1.2.0"
+    "streamroot-dashjs-p2p-bundle": "^1.5.0"
   }
   ...
 ```
 
-Wrapper is imported in [dash.js source handler](https://github.com/streamroot/videojs5-dashjs-p2p-source-handler/blob/master/src/js/videojs-dash.js):
+and is imported in [dash.js source handler](https://github.com/streamroot/videojs5-dashjs-p2p-source-handler/blob/master/src/js/videojs-dash.js):
 
 ```javascript
-import DashjsWrapper from 'streamroot-dashjs-p2p-wrapper';
+import DashjsP2PBundle from 'streamroot-dashjs-p2p-bundle';
 ```
 
-and instantiated after `dashjs.MediaPlayer` is created. `dashjs.MediaPlayer` instance, p2p config and live delay value are passed as parameters to wrapper constructor:
+and instantiated if `p2pConfig` is defined:
 
 ```javascript
-if (options && options.streamroot && options.streamroot.p2pConfig) {
-  var liveDelay = 30;
-  this.dashjsWrapper_ = new DashjsWrapper(
-    this.mediaPlayer_,
-    options.streamroot.p2pConfig,
-    liveDelay
-  );
+if (!options || !options.streamroot || !options.streamroot.p2pConfig) {
+  throw new Error('p2pConfig is not defined!');
 }
+
+// initializing streamroot-p2p-bundle
+this.mediaPlayer_ = DashjsP2PBundle.MediaPlayer(Html5DashJS.context_).create(options.streamroot.p2pConfig);
 ```
 
 p2pConfig is described [here](https://streamroot.readme.io/docs/p2p-config). Check it to get better understanding on what can be configured.

--- a/example.html
+++ b/example.html
@@ -21,7 +21,6 @@
 
 <body>
   <script src="node_modules/video.js/dist/video.js"></script>
-  <script src="node_modules/dashjs/dist/dash.all.debug.js"></script>
   <script src="dist/videojs5-dashjs-p2p-source-handler.js"></script>
 
   <script>

--- a/example.html
+++ b/example.html
@@ -34,6 +34,7 @@
     videoEl.setAttribute('controls', '');
     videoEl.setAttribute('width', '600');
     videoEl.setAttribute('height', '300');
+    videoEl.setAttribute('muted', '');
     videoEl.className = 'video-js vjs-default-skin';
     fixture.appendChild(videoEl);
 

--- a/example.html
+++ b/example.html
@@ -53,7 +53,7 @@
 
     player.ready(function() {
       player.src({
-        src: 'http://dash.edgesuite.net/envivio/EnvivioDash3/manifest.mpd',
+        src: 'http://wowza-test.streamroot.io/vodOrigin/tos.smil/manifest.mpd',
         type: 'application/dash+xml'
       });
     });

--- a/package.json
+++ b/package.json
@@ -25,10 +25,9 @@
     "video.js": "global:videojs"
   },
   "dependencies": {
-    "dashjs": "2.1.1",
     "global": "^4.3.0",
     "video.js": "^5.0.0",
-    "streamroot-dashjs-p2p-wrapper": "^1.2.0"
+    "streamroot-dashjs-p2p-bundle": "^1.5.0"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.6.0",

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -1,7 +1,6 @@
 import window from 'global/window';
 import videojs from 'video.js';
-import dashjs from 'dashjs';
-import DashjsWrapper from 'streamroot-dashjs-p2p-wrapper';
+import DashjsP2PBundle from 'streamroot-dashjs-p2p-bundle';
 
 let
   isArray = function(a) {
@@ -60,13 +59,12 @@ class Html5DashJS {
 
     // reuse MediaPlayer if it already exists
     if (!this.mediaPlayer_) {
-      this.mediaPlayer_ = dashjs.MediaPlayer(Html5DashJS.context_).create();
-
-      // initializing streamroot-dashjs-p2p-wrapper
-      if (options && options.streamroot && options.streamroot.p2pConfig) {
-        let liveDelay = 30;
-        this.dashjsWrapper_ = new DashjsWrapper(this.mediaPlayer_, options.streamroot.p2pConfig, liveDelay);
+      if (!options || !options.streamroot || !options.streamroot.p2pConfig) {
+        throw new Error('p2pConfig is not defined!');
       }
+
+      // initializing streamroot-p2p-bundle
+      this.mediaPlayer_ = DashjsP2PBundle.MediaPlayer(Html5DashJS.context_).create(options.streamroot.p2pConfig);
     }
 
     // Log MedaPlayer messages through video.js

--- a/test/dashjs.test.js
+++ b/test/dashjs.test.js
@@ -67,6 +67,12 @@
         playerId: el.getAttribute('id'),
         dash: {
           limitBitrateByPortal: limitBitrateByPortal
+        },
+        streamroot: {
+          p2pConfig: {
+            streamrootKey: 'key',
+            debug: true
+          }
         }
       };
       tech.el = function() { return el; };
@@ -77,8 +83,12 @@
         return {
           create: function () {
             return {
+              extend: function() {
+              },
               initialize: function () {
                 startupCalled = true;
+              },
+              on: function() {
               },
 
               attachView: function () {
@@ -109,6 +119,8 @@
               setLimitBitrateByPortal: function (value) {
                 setLimitBitrateByPortalCalled = true;
                 setLimitBitrateByPortalValue = value;
+              },
+              setLiveDelay: function () {
               }
             };
           }

--- a/test/index.html
+++ b/test/index.html
@@ -14,9 +14,6 @@
   <link rel="stylesheet" href="../node_modules/video.js/dist/video-js.css" />
   <script src="../node_modules/video.js/dist/video.js"></script>
 
-  <!-- Dash.js -->
-  <script src="../node_modules/dashjs/dist/dash.all.debug.js"></script>
-
   <!-- videojs-contrib-dash -->
   <script src="../dist/videojs5-dashjs-p2p-source-handler.js"></script>
 </head>

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -48,7 +48,7 @@
         player.one('loadstart', done);
 
         player.src({
-          src: 'http://dash.edgesuite.net/envivio/EnvivioDash3/manifest.mpd',
+          src: 'http://wowza-test.streamroot.io/vodOrigin/tos.smil/manifest.mpd',
           type: 'application/dash+xml'
         });
 

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -29,7 +29,19 @@
       videoEl.className = 'video-js vjs-default-skin';
       this.fixture.appendChild(videoEl);
 
-      player = videojs('vid');
+      player = videojs('vid', {
+        html5: {
+          dash: {
+            limitBitrateByPortal: true
+          },
+          streamroot: {
+            p2pConfig: {
+              streamrootKey: 'key',
+              debug: true
+            }
+          }
+        }
+      });
       this.player = player;
 
       player.ready(function() {

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -5,7 +5,6 @@ module.exports = function(config) {
     files: [
       'node_modules/video.js/dist/video-js.css',
       'node_modules/video.js/dist/video.js',
-      'node_modules/dashjs/dist/dash.all.debug.js',
       'dist/videojs5-dashjs-p2p-source-handler.js',
       'test/integration.test.js',
       'test/globals.test.js',


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/128218253

This PR replaces `dashjs-p2p-wrapper` by `dashjs-p2p-bundle`, giving us control over dash.js version being used(because it's shipped in bundle).