### PR TITLE
Fixing duration display for live streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 
 ### Fixed
 - Disabled segment prefetching
+- Content duration display for live streams
 
 ## [Unreleased]
 

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -67,6 +67,10 @@ class Html5DashJS {
       this.mediaPlayer_ = DashjsP2PBundle.MediaPlayer(Html5DashJS.context_).create(options.streamroot.p2pConfig);
     }
 
+    this.mediaPlayer_.on('manifestloaded', ({data}) => {
+      this._duration = data.type === 'static' ? data.mediaPresentationDuration : Infinity;
+    });
+
     // Log MedaPlayer messages through video.js
     if (Html5DashJS.useVideoJSDebug) {
       videojs.log.warn('useVideoJSDebug has been deprecated.' +
@@ -92,6 +96,10 @@ class Html5DashJS {
     this.mediaPlayer_.attachView(this.el_);
 
     this.tech_.triggerReady();
+  }
+
+  duration() {
+    return this._duration || this.el_.duration || 0;
   }
 
   /*


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/128218509
Quite simple -- setting duration to `Infinity` for live streams, so video.js can properly display the duration.