### PR TITLE
Add option to disable dash.js debug log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 ## [Dev]
 
 ## [Unreleased]
+### Added
+- `debugLogToConsole` option to enable or disable Dash.js debug logging.
 
 ## [1.2.23] - 2017-07-26
+### Fixed
 - VJS 6 compatibility: use videojs.getTech instead of videojs.getComponent
 
 ## [1.2.2] - 2017-03-20

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ Putting it all together:
     var options = {
         html5: {
             dash: {
-              limitBitrateByPortal: true
+              limitBitrateByPortal: true,
+              debugLogToConsole: true
             },
             streamroot: {
                 p2pConfig: {
-                    streamrootKey: "YOUR_STREAMROOTKEY_HERE",
-                    debug: true
+                    streamrootKey: "YOUR_STREAMROOTKEY_HERE"
                 }
             }
         }

--- a/example.html
+++ b/example.html
@@ -33,11 +33,12 @@
     var player = videojs('vid', {
       html5: {
         dash: {
-          limitBitrateByPortal: true
+          limitBitrateByPortal: true,
+          debugLogToConsole: false,
         },
         streamroot: {
           p2pConfig: {
-            streamrootKey: "dev",
+            streamrootKey: "dev"
           }
         }
       }

--- a/example.html
+++ b/example.html
@@ -13,7 +13,7 @@
 
 <body>
   <script src="node_modules/video.js/dist/video.js"></script>
-  <script src="dist/videojs5-dashjs-p2p-source-handler.js"></script>
+  <script src="http://localhost:8080/videojs5-dashjs-p2p-source-handler.js"></script>
 
   <script>
     var fixture;
@@ -37,18 +37,14 @@
         },
         streamroot: {
           p2pConfig: {
-            streamrootKey: "a913c6b8-5037-4ed8-9c94-918f70c40320",
-            debug: true
+            streamrootKey: "dev",
           }
         }
       }
     });
 
     player.ready(function() {
-      player.src({
-        src: 'http://wowza-test.streamroot.io/vodOrigin/tos.smil/manifest.mpd',
-        type: 'application/dash+xml'
-      });
+      player.src('//wowza-test-cloudfront.streamroot.io/vodOrigin/tos1500.mp4/manifest.mpd');
     });
   </script>
 

--- a/src/js/videojs-dash.js
+++ b/src/js/videojs-dash.js
@@ -81,6 +81,13 @@ class Html5DashJS {
             Html5DashJS.beforeInitialize(player, this.mediaPlayer_);
         }
 
+        // Debug log must be silenced before initialize
+        if (options.dash && options.dash.debugLogToConsole) {
+            this.mediaPlayer_.getDebug().setLogToBrowserConsole(options.dash.debugLogToConsole);
+        } else {
+            this.mediaPlayer_.getDebug().setLogToBrowserConsole(false);
+        }
+
         // Must run controller before these two lines or else there is no
         // element to bind to.
         this.mediaPlayer_.initialize();


### PR DESCRIPTION
By default dash.js debug log is enabled, this PR turns it off by default and add an option to turn it on by source handler configuration.